### PR TITLE
Publish images to GHCR

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,4 +1,4 @@
-# This workflow will publish the release to Docker Hub
+# This workflow will build and publish the release to Docker Hub and GitHub Container Registry (GHCR)
 
 name: Publish Release
 
@@ -117,6 +117,9 @@ jobs:
     name: 🚀 Publish Release
     permissions:
       contents: write
+      packages: write
+      id-token: write
+      attestations: write
     timeout-minutes: 30
     runs-on: ubuntu-latest
 
@@ -148,10 +151,38 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push 🚀
+      - name: Login to GitHub Container Registry (GHCR) 🔐
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push to Docker Hub and GHCR 🚀
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: apptasticsoftware/trading-calendar:${{ env.new_version }}, apptasticsoftware/trading-calendar:latest
+          tags: |
+            apptasticsoftware/trading-calendar:latest
+            apptasticsoftware/trading-calendar:${{ env.new_version }}
+            ghcr.io/apptastic-software/trading-calendar:latest
+            ghcr.io/apptastic-software/trading-calendar:${{ env.new_version }}
+
+      - name: Attest build provenance for Docker Hub 🔏
+        id: attest-docker-hub
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: index.docker.io/apptasticsoftware/trading-calendar
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest build provenance for GHCR 🔏
+        id: attest-ghcr
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/apptasticsoftware/trading-calendar
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Publish images to GitHub container registry (GHCR).
```sh
docker pull ghcr.io/apptasticsoftware/trading-calendar:latest
```


Images will still be published to Docker Hub as before.